### PR TITLE
errwrap dependancy removed 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pki_custom
 credentials
 demo.sh
 !*/**
+*.DS_Store

--- a/plugin/pki/cert_util.go
+++ b/plugin/pki/cert_util.go
@@ -466,7 +466,7 @@ func validateOtherSANs(data *dataBundle, requested map[string][]string) (string,
 	}
 	allowed, err := parseOtherSANs(data.role.AllowedOtherSANs)
 	if err != nil {
-		return "", "", errwrap.Wrapf("error parsing role's allowed SANs: {{err}}", err)
+		return "", "", fmt.Errorf("error parsing role's allowed SANs: %w", err)
 	}
 	for oid, names := range requested {
 		for _, name := range names {
@@ -854,7 +854,7 @@ func generateCreationBundle(b *backend, data *dataBundle, isCA bool) error {
 	if sans := data.apiData.Get("other_sans").([]string); len(sans) > 0 {
 		requested, err := parseOtherSANs(sans)
 		if err != nil {
-			return errutil.UserError{Err: errwrap.Wrapf("could not parse requested other SAN: {{err}}", err).Error()}
+			return errutil.UserError{Err: fmt.Errorf("could not parse requested other SAN: %w", err).Error()}
 		}
 		badOID, badName, err := validateOtherSANs(data, requested)
 		switch {
@@ -1183,7 +1183,7 @@ func createCertificate(data *dataBundle) (*certutil.ParsedCertBundle, error) {
 	}
 
 	if err := handleOtherSANs(certTemplate, data.params.OtherSANs); err != nil {
-		return nil, errutil.InternalError{Err: errwrap.Wrapf("error marshaling other SANs: {{err}}", err).Error()}
+		return nil, errutil.InternalError{Err: fmt.Errorf("error marshaling other SANs: %w", err).Error()}
 	}
 
 	// Add this before calling addKeyUsages

--- a/plugin/pki/crl_util.go
+++ b/plugin/pki/crl_util.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -85,7 +84,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 
 		cert, err := x509.ParseCertificate(certEntry.Value)
 		if err != nil {
-			return nil, errwrap.Wrapf("error parsing certificate: {{err}}", err)
+			return nil, fmt.Errorf("error parsing certificate: %w", err)
 		}
 		if cert == nil {
 			return nil, fmt.Errorf("got a nil certificate")
@@ -125,7 +124,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 	case errutil.UserError:
 		return logical.ErrorResponse(fmt.Sprintf("Error during CRL building: %s", crlErr)), nil
 	case errutil.InternalError:
-		return nil, errwrap.Wrapf("error encountered during CRL building: {{err}}", crlErr)
+		return nil, fmt.Errorf("error encountered during CRL building: %w", crlErr)
 	}
 
 	resp := &logical.Response{
@@ -186,7 +185,7 @@ func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bo
 			// TODO: In this case, remove it and continue? How likely is this to
 			// happen? Alternately, could skip it entirely, or could implement a
 			// delete function so that there is a way to remove these
-			return errutil.InternalError{Err: "found revoked serial but actual certificate is empty"}
+			return errutil.InternalError{Err: fmt.Sprintf("found revoked serial but actual certificate is empty")}
 		}
 
 		err = revokedEntry.DecodeJSON(&revInfo)

--- a/plugin/pki/crl_util.go
+++ b/plugin/pki/crl_util.go
@@ -185,7 +185,7 @@ func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bo
 			// TODO: In this case, remove it and continue? How likely is this to
 			// happen? Alternately, could skip it entirely, or could implement a
 			// delete function so that there is a way to remove these
-			return errutil.InternalError{Err: fmt.Sprintf("found revoked serial but actual certificate is empty")}
+			return errutil.InternalError{Err: "found revoked serial but actual certificate is empty"}
 		}
 
 		err = revokedEntry.DecodeJSON(&revInfo)

--- a/plugin/pki/path_config_ca.go
+++ b/plugin/pki/path_config_ca.go
@@ -2,8 +2,8 @@ package pki
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
@@ -62,7 +62,7 @@ func (b *backend) pathCAWrite(ctx context.Context, req *logical.Request, data *f
 
 	cb, err := parsedBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw values into cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw values into cert bundle: %w", err)
 	}
 
 	entry, err := logical.StorageEntryJSON("config/ca_bundle", cb)

--- a/plugin/pki/path_config_crl.go
+++ b/plugin/pki/path_config_crl.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -117,7 +116,7 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 		case errutil.UserError:
 			return logical.ErrorResponse(fmt.Sprintf("Error during CRL building: %s", crlErr)), nil
 		case errutil.InternalError:
-			return nil, errwrap.Wrapf("error encountered during CRL building: {{err}}", crlErr)
+			return nil, fmt.Errorf("error encountered during CRL building: %w", crlErr)
 		}
 	}
 

--- a/plugin/pki/path_intermediate.go
+++ b/plugin/pki/path_intermediate.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
@@ -88,7 +87,7 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 
 	csrb, err := parsedBundle.ToCSRBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw CSR bundle to CSR bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw CSR bundle to CSR bundle: %w", err)
 	}
 
 	resp = &logical.Response{
@@ -198,12 +197,12 @@ func (b *backend) pathSetSignedIntermediate(ctx context.Context, req *logical.Re
 	}
 
 	if err := inputBundle.Verify(); err != nil {
-		return nil, errwrap.Wrapf("verification of parsed bundle failed: {{err}}", err)
+		return nil, fmt.Errorf("verification of parsed bundle failed: %w", err)
 	}
 
 	cb, err = inputBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw values into cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw values into cert bundle: %w", err)
 	}
 
 	entry, err = logical.StorageEntryJSON("config/ca_bundle", cb)

--- a/plugin/pki/path_issue_sign.go
+++ b/plugin/pki/path_issue_sign.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -146,7 +145,6 @@ func (b *backend) pathSign(ctx context.Context, req *logical.Request, data *fram
 // pathSignVerbatim issues a certificate from a submitted CSR, *not* subject to
 // role restrictions
 func (b *backend) pathSignVerbatim(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-
 	roleName := data.Get("role").(string)
 
 	// Get the role if one was specified
@@ -237,12 +235,12 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 
 	signingCB, err := signingBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw signing bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw signing bundle to cert bundle: %w", err)
 	}
 
 	cb, err := parsedBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw cert bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw cert bundle to cert bundle: %w", err)
 	}
 
 	respData := map[string]interface{}{
@@ -323,7 +321,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 			Value: parsedBundle.CertificateBytes,
 		})
 		if err != nil {
-			return nil, errwrap.Wrapf("unable to store certificate locally: {{err}}", err)
+			return nil, fmt.Errorf("unable to store certificate locally: %w", err)
 		}
 	}
 
@@ -338,7 +336,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 
 	policyMap, err := getPolicyRoleMap(ctx, req.Storage)
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to get policy map: {{err}}", err)
+		return nil, fmt.Errorf("unable to get policy map: %w", err)
 	}
 	if policyMap.Roles[data.Get("role").(string)].ImportPolicy != "" {
 		sn := normalizeSerial(cb.SerialNumber)

--- a/plugin/pki/path_revoke.go
+++ b/plugin/pki/path_revoke.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -69,7 +68,7 @@ func (b *backend) pathRotateCRLRead(ctx context.Context, req *logical.Request, d
 	case errutil.UserError:
 		return logical.ErrorResponse(fmt.Sprintf("Error during CRL building: %s", crlErr)), nil
 	case errutil.InternalError:
-		return nil, errwrap.Wrapf("error encountered during CRL building: {{err}}", crlErr)
+		return nil, fmt.Errorf("error encountered during CRL building: %w", crlErr)
 	default:
 		return &logical.Response{
 			Data: map[string]interface{}{

--- a/plugin/pki/path_roles.go
+++ b/plugin/pki/path_roles.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
@@ -509,7 +508,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 	if len(otherSANs) > 0 {
 		_, err := parseOtherSANs(otherSANs)
 		if err != nil {
-			return logical.ErrorResponse(errwrap.Wrapf("error parsing allowed_other_sans: {{err}}", err).Error()), nil
+			return logical.ErrorResponse(fmt.Errorf("error parsing allowed_other_sans: %w", err).Error()), nil
 		}
 		entry.AllowedOtherSANs = otherSANs
 	}

--- a/plugin/pki/path_root.go
+++ b/plugin/pki/path_root.go
@@ -11,7 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
+
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -156,7 +157,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 
 	cb, err := parsedBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw cert bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw cert bundle to cert bundle: %w", err)
 	}
 
 	resp := &logical.Response{
@@ -219,7 +220,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 		Value: parsedBundle.CertificateBytes,
 	})
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to store certificate locally: {{err}}", err)
+		return nil, fmt.Errorf("unable to store certificate locally: %w", err)
 	}
 
 	// For ease of later use, also store just the certificate at a known
@@ -313,17 +314,17 @@ func (b *backend) pathCASignIntermediate(ctx context.Context, req *logical.Reque
 	}
 
 	if err := parsedBundle.Verify(); err != nil {
-		return nil, errwrap.Wrapf("verification of parsed bundle failed: {{err}}", err)
+		return nil, fmt.Errorf("verification of parsed bundle failed: %w", err)
 	}
 
 	signingCB, err := signingBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw signing bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw signing bundle to cert bundle: %w", err)
 	}
 
 	cb, err := parsedBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw cert bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw cert bundle to cert bundle: %w", err)
 	}
 
 	resp := &logical.Response{
@@ -370,7 +371,7 @@ func (b *backend) pathCASignIntermediate(ctx context.Context, req *logical.Reque
 		Value: parsedBundle.CertificateBytes,
 	})
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to store certificate locally: {{err}}", err)
+		return nil, fmt.Errorf("unable to store certificate locally: %w", err)
 	}
 
 	if parsedBundle.Certificate.MaxPathLen == 0 {
@@ -417,7 +418,7 @@ func (b *backend) pathCASignSelfIssued(ctx context.Context, req *logical.Request
 
 	signingCB, err := signingBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw signing bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw signing bundle to cert bundle: %w", err)
 	}
 
 	urls := &urlEntries{}
@@ -430,7 +431,7 @@ func (b *backend) pathCASignSelfIssued(ctx context.Context, req *logical.Request
 
 	newCert, err := x509.CreateCertificate(rand.Reader, cert, signingBundle.Certificate, cert.PublicKey, signingBundle.PrivateKey)
 	if err != nil {
-		return nil, errwrap.Wrapf("error signing self-issued certificate: {{err}}", err)
+		return nil, fmt.Errorf("error signing self-issued certificate: %w", err)
 	}
 	if len(newCert) == 0 {
 		return nil, fmt.Errorf("nil cert was created when signing self-issued certificate")

--- a/plugin/pki/path_tidy.go
+++ b/plugin/pki/path_tidy.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -96,19 +95,19 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 			if tidyCertStore {
 				serials, err := req.Storage.List(ctx, "certs/")
 				if err != nil {
-					return errwrap.Wrapf("error fetching list of certs: {{err}}", err)
+					return fmt.Errorf("error fetching list of certs: %w", err)
 				}
 
 				for _, serial := range serials {
 					certEntry, err := req.Storage.Get(ctx, "certs/"+serial)
 					if err != nil {
-						return errwrap.Wrapf(fmt.Sprintf("error fetching certificate %q: {{err}}", serial), err)
+						return fmt.Errorf("error fetching certificate %q: %w", serial, err)
 					}
 
 					if certEntry == nil {
 						logger.Warn("certificate entry is nil; tidying up since it is no longer useful for any server operations", "serial", serial)
 						if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-							return errwrap.Wrapf(fmt.Sprintf("error deleting nil entry with serial %s: {{err}}", serial), err)
+							return fmt.Errorf("error deleting nil entry with serial %s: %w", serial, err)
 						}
 						continue
 					}
@@ -116,18 +115,18 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 					if certEntry.Value == nil || len(certEntry.Value) == 0 {
 						logger.Warn("certificate entry has no value; tidying up since it is no longer useful for any server operations", "serial", serial)
 						if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-							return errwrap.Wrapf(fmt.Sprintf("error deleting entry with nil value with serial %s: {{err}}", serial), err)
+							return fmt.Errorf("error deleting entry with nil value with serial %s: %w", serial, err)
 						}
 					}
 
 					cert, err := x509.ParseCertificate(certEntry.Value)
 					if err != nil {
-						return errwrap.Wrapf(fmt.Sprintf("unable to parse stored certificate with serial %q: {{err}}", serial), err)
+						return fmt.Errorf("unable to parse stored certificate with serial %q: %w", serial, err)
 					}
 
 					if time.Now().After(cert.NotAfter.Add(bufferDuration)) {
 						if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-							return errwrap.Wrapf(fmt.Sprintf("error deleting serial %q from storage: {{err}}", serial), err)
+							return fmt.Errorf("error deleting serial %q from storage: %w", serial, err)
 						}
 					}
 				}
@@ -141,46 +140,46 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 
 				revokedSerials, err := req.Storage.List(ctx, "revoked/")
 				if err != nil {
-					return errwrap.Wrapf("error fetching list of revoked certs: {{err}}", err)
+					return fmt.Errorf("error fetching list of revoked certs: %w", err)
 				}
 
 				var revInfo revocationInfo
 				for _, serial := range revokedSerials {
 					revokedEntry, err := req.Storage.Get(ctx, "revoked/"+serial)
 					if err != nil {
-						return errwrap.Wrapf(fmt.Sprintf("unable to fetch revoked cert with serial %q: {{err}}", serial), err)
+						return fmt.Errorf("unable to fetch revoked cert with serial %q: %w", serial, err)
 					}
 
 					if revokedEntry == nil {
 						logger.Warn("revoked entry is nil; tidying up since it is no longer useful for any server operations", "serial", serial)
 						if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
-							return errwrap.Wrapf(fmt.Sprintf("error deleting nil revoked entry with serial %s: {{err}}", serial), err)
+							return fmt.Errorf("error deleting nil revoked entry with serial %s: %w", serial, err)
 						}
 					}
 
 					if revokedEntry.Value == nil || len(revokedEntry.Value) == 0 {
 						logger.Warn("revoked entry has nil value; tidying up since it is no longer useful for any server operations", "serial", serial)
 						if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
-							return errwrap.Wrapf(fmt.Sprintf("error deleting revoked entry with nil value with serial %s: {{err}}", serial), err)
+							return fmt.Errorf("error deleting revoked entry with nil value with serial %s: %w", serial, err)
 						}
 					}
 
 					err = revokedEntry.DecodeJSON(&revInfo)
 					if err != nil {
-						return errwrap.Wrapf(fmt.Sprintf("error decoding revocation entry for serial %q: {{err}}", serial), err)
+						return fmt.Errorf("error decoding revocation entry for serial %q: %w", serial, err)
 					}
 
 					revokedCert, err := x509.ParseCertificate(revInfo.CertificateBytes)
 					if err != nil {
-						return errwrap.Wrapf(fmt.Sprintf("unable to parse stored revoked certificate with serial %q: {{err}}", serial), err)
+						return fmt.Errorf("unable to parse stored revoked certificate with serial %q: %w", serial, err)
 					}
 
 					if time.Now().After(revokedCert.NotAfter.Add(bufferDuration)) {
 						if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
-							return errwrap.Wrapf(fmt.Sprintf("error deleting serial %q from revoked list: {{err}}", serial), err)
+							return fmt.Errorf("error deleting serial %q from revoked list: %w", serial, err)
 						}
 						if err := req.Storage.Delete(ctx, "certs/"+serial); err != nil {
-							return errwrap.Wrapf(fmt.Sprintf("error deleting serial %q from store when tidying revoked: {{err}}", serial), err)
+							return fmt.Errorf("error deleting serial %q from store when tidying revoked: %w", serial, err)
 						}
 						tidiedRevoked = true
 					}


### PR DESCRIPTION
Removing a dependancy on errwrap as it is not in the Vault implementation of the PKI tool

https://github.com/hashicorp/vault/tree/main/builtin/logical/pki

PKI Monitor Code source can be diff'd against the above ^

With this dependancy removed diff'ing is easier so that fixes to the plugin core functionality (outside Venafi alterations) can be easily identified and submitted independently 